### PR TITLE
fix: 重构添加诊疗记录的页面逻辑

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -25,6 +25,7 @@ declare module '@vue/runtime-core' {
     ElSwitch: typeof import('element-plus/es')['ElSwitch']
     ElTable: typeof import('element-plus/es')['ElTable']
     ElTableColumn: typeof import('element-plus/es')['ElTableColumn']
+    ElUpload: typeof import('element-plus/es')['ElUpload']
     InfCard: typeof import('./src/components/InfCard.vue')['default']
     Loading: typeof import('element-plus/es')['ElLoadingDirective']
     MyBtn: typeof import('./src/components/MyBtn.vue')['default']

--- a/src/Layout/Layout.vue
+++ b/src/Layout/Layout.vue
@@ -1,8 +1,11 @@
 <template>
   <el-header>
     <div class="logo-box">
-      <img src="@/assets/img/logo.jpg" />
+      <img src="@/assets/img/logo.jpg" class="side-logo" />
+      <span v-if="hospitalInfo.name" class="hospital-name">{{ hospitalInfo.name }}</span>
       <span class="product">内镜清洗消毒系统</span>
+      <img v-if="hospitalInfo.logoUrl" :src="hospitalInfo.logoUrl" class="side-logo" />
+      <!-- <img v-else src="@/assets/img/logo.jpg" class="side-logo" /> -->
     </div>
     <div class="right-box">
       <span>
@@ -10,19 +13,27 @@
         <el-switch v-model="isSpeak" class="switch" @click="changeSpeak" />
       </span>
       <span class="blue" @click="toMonitor">
-        <el-icon class="house-icon"><Monitor /></el-icon>
+        <el-icon class="house-icon">
+          <Monitor />
+        </el-icon>
         <span class="text">监控</span>
       </span>
       <span v-show="isVisitor" class="blue" @click="toConRecord">
-        <el-icon class="house-icon"><Calendar /></el-icon>
+        <el-icon class="house-icon">
+          <Calendar />
+        </el-icon>
         <span class="text">诊疗记录</span>
       </span>
       <span>
-        <el-icon><User /></el-icon>
+        <el-icon>
+          <User />
+        </el-icon>
         <span class="text big-margin">{{ store.state.username }}</span>
       </span>
       <span class="red" @click="logout">
-        <el-icon><SwitchButton /></el-icon>
+        <el-icon>
+          <SwitchButton />
+        </el-icon>
         <span class="text">注销</span>
       </span>
     </div>
@@ -48,6 +59,7 @@
 import { Monitor, Calendar, User, SwitchButton } from '@element-plus/icons-vue';
 import user from '@/web/api/user';
 import confirm from '@/utils/confirm';
+import { getHospitalInfo } from '@/web/utils/hospitalInfo';
 
 const router = useRouter();
 // 基本布局页面挂载时跳转到首页
@@ -113,6 +125,7 @@ const asideList = reactive([
   {
     name: '医院管理',
     children: [
+      { label: '医院信息管理', name: 'hospitalInfo' },
       { label: '科室管理', name: 'dept' },
       { label: '用户管理', name: 'administrator' },
       { label: '护士管理', name: 'nurse' },
@@ -141,6 +154,19 @@ const asideList = reactive([
   //   children: [{ label: '耗材管理', name: 'consumption' }],
   // },
 ]);
+
+const hospitalInfo = ref(getHospitalInfo() || { name: '', logoUrl: '' });
+
+watchEffect(() => {
+  hospitalInfo.value = getHospitalInfo() || { name: '', logoUrl: '' };
+});
+
+// 监听页面存储变化，自动刷新（兼容手动刷新和弹窗保存后）
+window.addEventListener('storage', (e) => {
+  if (e.key === 'hospital_info') {
+    location.reload();
+  }
+});
 </script>
 
 <style lang="scss" scoped>
@@ -155,49 +181,71 @@ const asideList = reactive([
   color: #606266;
   background: #ffffff;
   box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.1);
+
   .logo-box {
     display: flex;
     align-items: center;
-    img {
+    /* 靠左排列，不居中 */
+    margin-right: 40px;
+    .side-logo {
+      width: 60px;
+      height: 60px;
+      object-fit: contain;
+      border-radius: 8px;
       margin-right: 10px;
-      width: 65px;
+      margin-left: 0;
     }
-    .text {
-      position: relative;
-      top: -2.8px;
-      margin: 0 5px;
-      font-size: 16px;
+    .center-title {
+      display: flex;
+      align-items: center;
+      gap: 30px;
+    }
+    .hospital-name {
+      font-size: 26px;
+      font-weight: 600;
+      color: #8b8c8f;
+      letter-spacing: 15px;
+      margin-right: 0;
+      margin-left: 0;
+      /* 让医院名和系统名视觉上连贯 */
     }
     .product {
       font-size: 26px;
-      // color: #0100fa;
+      font-weight: 600;
       color: #8b8c8f;
       letter-spacing: 15px;
+      margin-left: 0;
     }
   }
+
   .right-box {
     .switch {
       position: relative;
       top: -3px;
       margin-right: 20px;
     }
+
     .text {
       position: relative;
       top: -2.8px;
       margin: 0 5px;
       font-size: 16px;
     }
+
     .big-margin {
       margin-right: 15px;
     }
+
     .red {
       &:hover {
         cursor: pointer;
         color: red;
       }
     }
+
     .blue {
       margin-right: 15px;
+
       &:hover {
         cursor: pointer;
         color: #409eff;
@@ -205,30 +253,37 @@ const asideList = reactive([
     }
   }
 }
+
 .el-container {
   width: 100%;
   height: 100%;
+
   .el-aside {
     padding: 0.5% 0;
     height: 99%;
     background: #ffffff;
+
     .login-tip {
       color: #45dce7;
+
       &:hover {
         cursor: pointer;
         color: #409eff;
       }
+
       div {
         margin: 15px;
         font-size: 16px;
       }
     }
+
     .nav-title {
       margin-left: 20px;
       margin-bottom: 25px;
       font-size: 16px;
       color: #45dce7;
     }
+
     .nav {
       display: block;
       text-decoration: none;
@@ -236,20 +291,24 @@ const asideList = reactive([
       margin-bottom: 35px;
       font-size: 14px;
       color: #303133;
+
       &:hover {
         cursor: pointer;
         color: #45dce7;
       }
     }
+
     .router-link-active,
     .router-link-active span {
       color: #409eff;
     }
   }
+
   .el-main {
     background: url(../assets/img/background.png);
     background-size: cover;
   }
+
   .router-link-active {
     color: #409eff;
   }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -32,6 +32,15 @@ const routes = [
           requireAuth: true,
         },
       },
+      // 医院信息管理
+      {
+        path: 'hospitalInfo',
+        name: 'HospitalInfo',
+        component: () => import('@/views/Hospital/HospitalInfo.vue'),
+        meta: {
+          requireAuth: true,
+        },
+      },
       // 科室管理
       {
         // path: 'hospital/dept',

--- a/src/views/ConRecord/ConRecord.vue
+++ b/src/views/ConRecord/ConRecord.vue
@@ -931,7 +931,13 @@ const remove = async (id: number) => {
 // 导出记录
 const download = async () => {
   try {
-    const res = await conRecord.excel({});
+    let isAll = false;
+    if (listQuery.isAbnormal === '2') {
+      listQuery.isAbnormal = '';
+      isAll = true;
+    }
+    const res = await conRecord.excel(removeInvalid(listQuery));
+    if (isAll) listQuery.isAbnormal = '2';
     ElMessage.success('下载成功');
     down(res, '诊疗记录.xlsx');
   } catch (e) {

--- a/src/views/ConRecord/ConRecord.vue
+++ b/src/views/ConRecord/ConRecord.vue
@@ -23,12 +23,8 @@
         </el-select>
       </div>
       <div>
-        <my-btn
-          v-show="!isVisitor"
-          color="linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)"
-          @click="download"
-          >导出记录</my-btn
-        >
+        <my-btn v-show="!isVisitor" color="linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)"
+          @click="download">导出记录</my-btn>
         <my-btn color="#fff" class="border-btn" @click="add">添加诊疗记录</my-btn>
       </div>
     </div>
@@ -64,20 +60,10 @@
           <el-input v-model="listQuery.staffName" placeholder="请输入医生姓名" clearable @clear="getList" />
         </el-col>
         <el-col :span="5">
-          <el-date-picker
-            v-model="listQuery.beginTime"
-            type="date"
-            placeholder="请选择起始时间"
-            value-format="YYYY-MM-DD"
-          />
+          <el-date-picker v-model="listQuery.beginTime" type="date" placeholder="请选择起始时间" value-format="YYYY-MM-DD" />
         </el-col>
         <el-col :span="5">
-          <el-date-picker
-            v-model="listQuery.endTime"
-            type="date"
-            placeholder="请选择结束时间"
-            value-format="YYYY-MM-DD"
-          />
+          <el-date-picker v-model="listQuery.endTime" type="date" placeholder="请选择结束时间" value-format="YYYY-MM-DD" />
         </el-col>
         <el-col :span="5">
           <el-button type="primary" @click="getList"> 查询 </el-button>
@@ -115,63 +101,35 @@
         </el-table-column>
       </el-table>
       <!-- 分页 -->
-      <my-pagination
-        v-show="!isVisitor"
-        :list-query="listQuery"
-        :loading="tableLoad"
-        :get-list="getList"
-        :total="total"
-      ></my-pagination>
+      <my-pagination v-show="!isVisitor" :list-query="listQuery" :loading="tableLoad" :get-list="getList"
+        :total="total"></my-pagination>
     </div>
   </div>
 
-  <!-- 添加/修改洗消室弹窗 -->
-  <el-dialog
-    v-model="conRecordDialog"
-    v-loading="tableLoad"
-    :title="isModify ? '修改诊疗记录' : '添加诊疗记录'"
-    width="60%"
-  >
-    <el-form
-      ref="ruleFormRef"
-      :model="ruleForm"
-      :rules="rules"
-      label-position="left"
-      label-width="110px"
-      size="large"
-      class="form"
-    >
+  <!-- 添加/修改诊疗记录弹窗 -->
+  <el-dialog v-model="conRecordDialog" v-loading="tableLoad" :title="isModify ? '修改诊疗记录' : '添加诊疗记录'" width="60%">
+    <el-form ref="ruleFormRef" :model="ruleForm" :rules="rules" label-position="left" label-width="110px" size="large"
+      class="form">
       <el-row justify="start">
         <el-col :span="12">
-          <el-form-item :label="isModify ? '修改组合号:' : '组合号①：'" prop="ip_and_lensCode">
-            <el-input v-model="ruleForm.ip_and_lensCode" placeholder="输入示例:192.168.0.1=test" style="width: 350px" />
-            <div v-if="!ruleForm.ip_and_lensCode || !isIpAndLensCodeValid" style="color: red; font-size: 12px">
-              <template v-if="!ruleForm.ip_and_lensCode"> 组合号①必填 </template>
-              <template v-else> 格式不正确，示例：192.168.1.10=test </template>
-            </div>
+          <el-form-item :label="isModify ? '修改组合号:' : '组合号：'" prop="ip_and_lensCode">
+            <el-input v-model="comboInput" placeholder="内镜卡号请用“、”分隔" style="width: 350px" />
+            <div v-if="!comboValid" style="color: red; font-size: 12px">{{ comboError }}</div>
           </el-form-item>
         </el-col>
         <el-col :span="8">
           <el-form-item label="检查唯一号：" prop="examNo">
-            <el-input
-              v-model="ruleForm.examNo"
-              placeholder="输入后请点击查询"
-              style="width: 350px"
-              :disabled="isModify"
-            />
+            <el-input v-model="ruleForm.examNo" placeholder="输入后请点击查询" style="width: 350px" :disabled="isModify" />
             <div v-if="!ruleForm.examNo || !isExamNoValid" style="color: red; font-size: 12px">检查唯一号必填</div>
           </el-form-item>
         </el-col>
-        <el-col :span="4"
-          ><el-button :disabled="isModify" type="success" style="margin-left: 20px" @click="searchHaidong()"
-            >查询</el-button
-          ></el-col
-        >
+        <el-col :span="4"><el-button :disabled="isModify" type="success" style="margin-left: 20px"
+            @click="searchHaidong()">查询</el-button></el-col>
       </el-row>
       <!-- 新增组合号②输入框 -->
-      <el-row v-if="!isModify" justify="start">
+      <!-- <el-row v-if="!isModify" justify="start">
         <el-col :span="12">
-          <el-form-item label="启用组合号②：">
+          <el-form-item label="启用组合号②：" display="false">
             <el-switch v-model="enableLensCode2" />
           </el-form-item>
         </el-col>
@@ -179,32 +137,29 @@
       <el-row v-if="enableLensCode2" justify="start">
         <el-col :span="12">
           <el-form-item :label="isModify ? '修改的组合号②:' : '组合号②：'" prop="ip_and_lensCode2">
-            <el-input
-              v-model="ruleForm.ip_and_lensCode2"
-              placeholder="输入示例:192.168.0.2=test"
-              style="width: 350px"
-            />
+            <el-input v-model="ruleForm.ip_and_lensCode2" placeholder="输入示例:192.168.0.2=test" style="width: 350px" />
             <div v-if="!ruleForm.ip_and_lensCode2 || !isIpAndLensCode2Valid" style="color: red; font-size: 12px">
               <template v-if="!ruleForm.ip_and_lensCode2"> 组合号②必填 </template>
               <template v-else> 格式不正确，示例：192.168.1.10=test </template>
             </div>
           </el-form-item>
         </el-col>
-      </el-row>
+      </el-row> -->
       <!-- 展示查询后的信息 -->
       <el-row v-show="isSearch" justify="center" style="margin-bottom: 20px">
         <!-- <span class="choice-tips">提示：点击表格数据进行选择</span> -->
         <span class="choice-tips">提示：点击表格数据选择胃镜或肠镜检查类型</span>
-        <el-table
-          v-loading="tableLoad"
-          fit
-          border
-          size="small"
-          highlight-current-row
-          :data="searchData"
-          style="width: 100%"
-          @current-change="handleCurrentChange"
-        >
+        <el-table v-loading="tableLoad" fit border size="small" highlight-current-row :data="searchData"
+          style="width: 100%" @row-click="toggleSelectRow" :row-class-name="rowClassName">
+          <el-table-column label="序号" width="60">
+            <template #default="{ row }">
+              <span class="sel-checkbox" :class="{ checked: getRowSelIndex(row) !== '' }">
+                <span v-if="getRowSelIndex(row)" class="sel-index">{{ getRowSelIndex(row) }}</span>
+                <span v-else class="sel-index"></span>
+                <!-- <span v-if="getRowSelIndex(row)" class="sel-check">✔</span> -->
+              </span>
+            </template>
+          </el-table-column>
           <el-table-column label="病人姓名" prop="name"></el-table-column>
           <el-table-column label="病人号" prop="patLocalid"></el-table-column>
           <el-table-column label="检查号" prop="examNo"></el-table-column>
@@ -246,24 +201,20 @@
       </el-row>
       <!-- 状态提示 -->
       <el-row v-if="!isModify" justify="center" style="margin-bottom: 10px">
-        <span class="status-tips" :class="{ success: isSelected, warning: !isSelected }">
+        <!-- <span class="status-tips" :class="{ success: isSelected, warning: !isSelected }">
           {{ isSelected ? '✓ 已选择胃镜或肠镜检查类型，可以点击完成' : '⚠ 请优先查询并选择胃镜或肠镜检查类型' }}
-        </span>
+        </span> -->
       </el-row>
       <!-- 选择状态提示 -->
       <el-row v-if="enableLensCode2 && isSearch" justify="center" style="margin-bottom: 20px">
         <div class="selection-status">
-          <span
-            class="status-item"
-            :class="{ selected: selectedData1, nonGastro: selectedData1 && !isGastrointestinalData(selectedData1) }"
-          >
+          <span class="status-item"
+            :class="{ selected: selectedData1, nonGastro: selectedData1 && !isGastrointestinalData(selectedData1) }">
             选择①: {{ selectedData1 ? `${selectedData1.name} (${selectedData1.examClass})` : '未选择' }}
             <el-button v-if="selectedData1" type="danger" size="small" @click="cancelSelection(1)">取消</el-button>
           </span>
-          <span
-            class="status-item"
-            :class="{ selected: selectedData2, nonGastro: selectedData2 && !isGastrointestinalData(selectedData2) }"
-          >
+          <span class="status-item"
+            :class="{ selected: selectedData2, nonGastro: selectedData2 && !isGastrointestinalData(selectedData2) }">
             选择②: {{ selectedData2 ? `${selectedData2.name} (${selectedData2.examClass})` : '未选择' }}
             <el-button v-if="selectedData2" type="danger" size="small" @click="cancelSelection(2)">取消</el-button>
           </span>
@@ -276,42 +227,26 @@
           :color="isModify || isSelected ? 'linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)' : '#dcdfe6'"
           :disabled="!isModify && !isSelected"
           @click="update(ruleFormRef)" -->
-        <my-btn
-          :disabled="
-            !isModify &&
-            (!isSelected ||
-              !isIpAndLensCodeValid ||
-              (enableLensCode2 && !isIpAndLensCode2Valid) ||
-              !isExamNoValid ||
-              !isPatLocalidValid)
-          "
-          :style="{
-            background:
-              isModify || isSelected ? 'linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)' : '#dcdfe6',
-            color: isModify || isSelected ? '#fff' : '#a8abb2',
-            border: 'none',
-            marginRight: '32px',
-            cursor: 'pointer',
-            transition: 'all 0.2s ease',
-          }"
-          @click="update(ruleFormRef)"
-        >
+        <my-btn :disabled="!canSubmit" :style="{
+          background: canSubmit ? 'linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)' : '#dcdfe6',
+          color: canSubmit ? '#fff' : '#a8abb2',
+          border: 'none',
+          marginRight: '32px',
+          cursor: canSubmit ? 'pointer' : 'not-allowed',
+          transition: 'all 0.2s ease',
+        }" @click="update(ruleFormRef)">
           完成
         </my-btn>
-        <my-btn
-          color="#fff"
-          style="border: 1px solid #e4e7ed"
-          @click="
-            conRecordDialog = false;
-            isSearch = false;
-            isSelected = false;
-            forceSubmitCount = 0;
-            enableLensCode2 = false;
-            ruleForm.ip_and_lensCode2 = '';
-            selectedData1 = null;
-            selectedData2 = null;
-          "
-        >
+        <my-btn color="#fff" style="border: 1px solid #e4e7ed" @click="
+          conRecordDialog = false;
+        isSearch = false;
+        isSelected = false;
+        forceSubmitCount = 0;
+        ruleForm.ip_and_lensCode2 = '';
+        selectedData1 = null;
+        selectedData2 = null;
+        clearDialogData();
+        ">
           取消
         </my-btn>
       </el-row>
@@ -381,43 +316,50 @@ const ruleForm = reactive({
 const isSelected = ref(false); // 是否已选择检查类型
 const forceSubmitCount = ref(0); // 强制提交计数
 const lastSubmitTime = ref(0); // 上次提交时间
-const enableLensCode2 = ref(false); // 是否启用组合号②
+// 组合号2相关逻辑全部隐藏和关闭
+const enableLensCode2 = ref(false); // 始终为false，隐藏开关
 const selectedData1 = ref<any>(null); // 第一次选择的数据
 const selectedData2 = ref<any>(null); // 第二次选择的数据
 const ruleFormRef = ref<FormInstance>();
+
+// 重新定义表单校验规则
 const rules = reactive<FormRules>({
-  ip_and_lensCode: [
-    { required: true, message: '', trigger: 'blur, change' },
-    {
-      validator: (rule: any, value: string, callback: any) => {
-        // 校验格式：IP=xxx
-        const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=[^=]+$/;
-        if (!value || reg.test(value)) {
-          callback();
-        } else {
-          callback(new Error(''));
-        }
-      },
-      trigger: 'blur, change',
-    },
-  ],
-  ip_and_lensCode2: [
-    { required: true, message: '', trigger: 'blur, change' },
-    {
-      validator: (rule: any, value: string, callback: any) => {
-        // 校验格式：IP=xxx
-        const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=[^=]+$/;
-        if (!value || reg.test(value)) {
-          callback();
-        } else {
-          callback(new Error(''));
-        }
-      },
-      trigger: 'blur, change',
-    },
-  ],
   examNo: [{ required: true, message: '', trigger: 'blur, change' }],
+  ip_and_lensCode: [], // 不做el-form校验，交给自定义watch
 });
+// const rules = reactive<FormRules>({
+//   ip_and_lensCode: [
+//     { required: true, message: '', trigger: 'blur, change' },
+//     {
+//       validator: (rule: any, value: string, callback: any) => {
+//         // 校验格式：IP=xxx
+//         const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=[^=]+$/;
+//         if (!value || reg.test(value)) {
+//           callback();
+//         } else {
+//           callback(new Error(''));
+//         }
+//       },
+//       trigger: 'blur, change',
+//     },
+//   ],
+//   ip_and_lensCode2: [
+//     { required: true, message: '', trigger: 'blur, change' },
+//     {
+//       validator: (rule: any, value: string, callback: any) => {
+//         // 校验格式：IP=xxx
+//         const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=[^=]+$/;
+//         if (!value || reg.test(value)) {
+//           callback();
+//         } else {
+//           callback(new Error(''));
+//         }
+//       },
+//       trigger: 'blur, change',
+//     },
+//   ],
+//   examNo: [{ required: true, message: '', trigger: 'blur, change' }],
+// });
 
 // 实时校验组合号格式，决定按钮是否可用
 const isIpAndLensCodeValid = computed(() => {
@@ -438,6 +380,27 @@ const isExamNoValid = computed(() => {
   return typeof ruleForm.examNo === 'string' && ruleForm.examNo.trim().length > 0;
 });
 
+// 组合号输入框实时校验
+const isComboValid = computed(() => {
+  if (!comboInput.value || comboInput.value.trim() === '') {
+    comboError.value = '组合号必填';
+    return false;
+  }
+  // 校验格式：IP=卡号1、卡号2...，IP为IPv4
+  const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=.+$/;
+  if (!reg.test(comboInput.value)) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return false;
+  }
+  const match = comboInput.value.match(/^(.*?)=(.*)$/);
+  if (!match) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return false;
+  }
+  // comboError.value = '';
+  return true;
+});
+
 // 检查号实时校验
 const isPatLocalidValid = computed(() => {
   return !!ruleForm.patLocalid && ruleForm.patLocalid.trim().length > 0;
@@ -454,13 +417,197 @@ const searchData = ref<any[]>([]);
  * 暂时将haidong 的ip修改到本地,方便测试
  */
 
+// 新增：多选序号管理
+const selectedRows = ref<any[]>([]); // 存储已选数据及序号
+const comboIp = ref(''); // 组合号IP部分
+const comboLensCodes = ref<string[]>([]); // 组合号内镜卡号数组
+const comboInput = ref(''); // 组合号输入框内容
+const comboError = ref(''); // 组合号输入错误提示
+const examNoError = ref(''); // 检查唯一号输入错误提示
+
+// 新增：组合号输入框格式和数量校验
+const comboValid = computed(() => {
+  if (!comboInput.value || comboInput.value.trim() === '') {
+    comboError.value = '组合号必填';
+    return false;
+  }
+  // 校验格式：IP=卡号1、卡号2...，IP为IPv4
+  const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=.+$/;
+  if (!reg.test(comboInput.value)) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return false;
+  }
+  const match = comboInput.value.match(/^(.*?)=(.*)$/);
+  if (!match) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return false;
+  }
+  const lensArr = match[2].split('、').map(s => s.trim()).filter(Boolean);
+  if (selectedRows.value.length === 0) {
+    comboError.value = '请先选择数据';
+    return false;
+  }
+  if (lensArr.length !== selectedRows.value.length) {
+    comboError.value = `已选${selectedRows.value.length}条数据，当前输入${lensArr.length}个内镜卡号，二者数量需一致`;
+    return false;
+  }
+  comboError.value = '';
+  return true;
+});
+
+// 检查唯一号输入框的错误提示逻辑
+watch(() => ruleForm.examNo, (val) => {
+  if (!val || !isExamNoValid.value) {
+    examNoError.value = '请填写有效的检查唯一号';
+  } else {
+    examNoError.value = '';
+  }
+});
+
+// 组合号输入框的错误提示逻辑
+// watch(comboInput, (val) => {
+//   if (!val || val.trim() === '') {
+//     comboError.value = '组合号必填';
+//     return;
+//   }
+//   const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=.+$/;
+//   if (!reg.test(val)) {
+//     comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+//     return;
+//   }
+//   const match = val.match(/^(.*?)=(.*)$/);
+//   if (!match) {
+//     comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+//     return;
+//   }
+//   const lensArr = match[2].split('、').map(s => s.trim()).filter(Boolean);
+//   if (selectedRows.value.length === 0) {
+//     comboError.value = '请先选择数据';
+//     return;
+//   }
+//   if (lensArr.length !== selectedRows.value.length) {
+//     comboError.value = `已选${selectedRows.value.length}条数据，当前输入${lensArr.length}个内镜卡号，二者数量需一致`;
+//     return;
+//   }
+//   comboError.value = '';
+// });
+
+// 监听组合号输入，动态分割卡号
+watch(comboInput, (val) => {
+  const match = val.match(/^(.*?)=(.*)$/);
+  if (match) {
+    comboIp.value = match[1].trim();
+    comboLensCodes.value = match[2].split('、').map(s => s.trim()).filter(Boolean);
+  } else {
+    comboIp.value = '';
+    comboLensCodes.value = [];
+  }
+});
+
+// 自动补充"、"符号的逻辑
+let autoAddTimer: NodeJS.Timeout | null = null;
+watch(comboInput, (val) => {
+  // 清除之前的定时器
+  if (autoAddTimer) {
+    clearTimeout(autoAddTimer);
+    autoAddTimer = null;
+  }
+  
+  // 检查是否符合IP=格式
+  const match = val.match(/^(.*?)=(.*)$/);
+  if (match) {
+    const ipPart = match[1].trim();
+    const contentPart = match[2];
+    
+    // 验证IP格式
+    const ipReg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$/;
+    if (ipReg.test(ipPart) && contentPart && !contentPart.endsWith('、')) {
+      // 如果内容部分不为空且不以"、"结尾，设置2秒后自动补充
+      autoAddTimer = setTimeout(() => {
+        if (comboInput.value && !comboInput.value.endsWith('、')) {
+          comboInput.value += '、';
+        }
+      }, 1500);
+    }
+  }
+});
+
+// 组件卸载时清除定时器
+onUnmounted(() => {
+  if (autoAddTimer) {
+    clearTimeout(autoAddTimer);
+  }
+});
+
+// 实时错误提示
+watch([comboInput, selectedRows], ([val, sel]) => {
+  if (!val || val.trim() === '') {
+    comboError.value = '组合号必填';
+    return;
+  }
+  const reg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=.+$/;
+  if (!reg.test(val)) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return;
+  }
+  const match = val.match(/^(.*?)=(.*)$/);
+  if (!match) {
+    comboError.value = '格式不正确，示例：192.168.1.10=test1、test2';
+    return;
+  }
+  const lensArr = match[2].split('、').map(s => s.trim()).filter(Boolean);
+  if (sel.length === 0) {
+    comboError.value = '请先选择数据';
+    return;
+  }
+  if (lensArr.length !== sel.length) {
+    comboError.value = `已选${sel.length}条数据，当前输入${lensArr.length}个内镜卡号，二者数量需一致`;
+    return;
+  }
+  comboError.value = '';
+});
+
+// // 监听组合号输入，动态分割卡号
+// watch(comboInput, (val) => {
+//   const match = val.match(/^(.*?)=(.*)$/);
+//   if (match) {
+//     comboIp.value = match[1].trim();
+//     comboLensCodes.value = match[2].split('、').map(s => s.trim()).filter(Boolean);
+//   } else {
+//     comboIp.value = '';
+//     comboLensCodes.value = [];
+//   }
+//   // 实时校验
+//   if (!forceSubmitCount.value && selectedRows.value.length !== comboLensCodes.value.length) {
+//     comboError.value = `已选${selectedRows.value.length}条，输入${comboLensCodes.value.length}个卡号，数量需一致`;
+//   } else {
+//     comboError.value = '';
+//   }
+// });
+
+// 表格多选序号列逻辑
+const toggleSelectRow = (row: any) => {
+  const idx = selectedRows.value.findIndex(r => r.examNo === row.examNo);
+  if (idx === -1) {
+    selectedRows.value.push(row);
+  } else {
+    selectedRows.value.splice(idx, 1);
+  }
+  // 重新编号
+  selectedRows.value = selectedRows.value.map((r, i) => ({ ...r, _selIndex: i + 1 }));
+};
+const getRowSelIndex = (row: any) => {
+  const idx = selectedRows.value.findIndex(r => r.examNo === row.examNo);
+  return idx === -1 ? '' : (idx + 1);
+};
+
+// 表格高亮选中行
+const rowClassName = (row: any) => {
+  return getRowSelIndex(row) !== '' ? 'selected-row' : '';
+};
+
 const searchHaidong = async () => {
   try {
-    // 验证必填字段
-    if (!ruleForm.ip_and_lensCode.trim()) {
-      ElMessage.error('请先输入组合号');
-      return;
-    }
     if (!ruleForm.examNo.trim()) {
       ElMessage.error('请先输入检查唯一号');
       return;
@@ -523,6 +670,11 @@ const searchHaidong = async () => {
         console.log('未找到匹配的行②:', currentSelected2.examNo);
       }
     }
+
+    // 清空多选
+    selectedRows.value = [];
+    // comboInput.value = '';
+    comboError.value = '';
 
     // 清除表格当前选中行的指针
     nextTick(() => {
@@ -668,51 +820,99 @@ const cancelSelection = (number: number) => {
 };
 
 // 监听组合号②开关变化
-watch(enableLensCode2, (newVal, oldVal) => {
-  // 只有在开关状态真正改变时才清空数据
-  if (oldVal !== undefined) {
-    // 避免初始化时触发
-    if (!newVal) {
-      // 关闭开关时清空双选数据
-      selectedData1.value = null;
-      selectedData2.value = null;
-      isSelected.value = false;
-      // 清除所有标记
-      searchData.value.forEach((item) => {
-        item.markNumber = '';
-      });
-    }
-    // 开启开关时不清除数据，保持现有选择状态
-    isSelected.value = false;
-  }
-});
+// watch(enableLensCode2, (newVal, oldVal) => {
+//   // 只有在开关状态真正改变时才清空数据
+//   if (oldVal !== undefined) {
+//     // 避免初始化时触发
+//     if (!newVal) {
+//       // 关闭开关时清空双选数据
+//       selectedData1.value = null;
+//       selectedData2.value = null;
+//       isSelected.value = false;
+//       // 清除所有标记
+//       searchData.value.forEach((item) => {
+//         item.markNumber = '';
+//       });
+//     }
+//     // 开启开关时不清除数据，保持现有选择状态
+//     isSelected.value = false;
+//   }
+// });
+
 
 // 监听选择数据变化，实时更新按钮状态
-watch(
-  [selectedData1, selectedData2],
-  () => {
-    // 实时检查双选状态
-    if (selectedData1.value && selectedData2.value) {
-      const isGastroscopy1 =
-        selectedData1.value.examSubclass.includes('胃镜') || selectedData1.value.itemName.includes('胃镜');
-      const isColonoscopy1 =
-        selectedData1.value.examSubclass.includes('肠镜') || selectedData1.value.itemName.includes('肠镜');
-      const isGastroscopy2 =
-        selectedData2.value.examSubclass.includes('胃镜') || selectedData2.value.itemName.includes('胃镜');
-      const isColonoscopy2 =
-        selectedData2.value.examSubclass.includes('肠镜') || selectedData2.value.itemName.includes('肠镜');
+// watch(
+//   [selectedData1, selectedData2],
+//   () => {
+//     // 实时检查双选状态
+//     if (selectedData1.value && selectedData2.value) {
+//       const isGastroscopy1 =
+//         selectedData1.value.examSubclass.includes('胃镜') || selectedData1.value.itemName.includes('胃镜');
+//       const isColonoscopy1 =
+//         selectedData1.value.examSubclass.includes('肠镜') || selectedData1.value.itemName.includes('肠镜');
+//       const isGastroscopy2 =
+//         selectedData2.value.examSubclass.includes('胃镜') || selectedData2.value.itemName.includes('胃镜');
+//       const isColonoscopy2 =
+//         selectedData2.value.examSubclass.includes('肠镜') || selectedData2.value.itemName.includes('肠镜');
 
-      const isBothGastrointestinal = (isGastroscopy1 || isColonoscopy1) && (isGastroscopy2 || isColonoscopy2);
-      isSelected.value = isBothGastrointestinal;
-    } else {
-      isSelected.value = false;
-    }
-  },
-  { immediate: true }
-);
+//       const isBothGastrointestinal = (isGastroscopy1 || isColonoscopy1) && (isGastroscopy2 || isColonoscopy2);
+//       isSelected.value = isBothGastrointestinal;
+//     } else {
+//       isSelected.value = false;
+//     }
+//   },
+//   { immediate: true }
+// );
+
+// 新增：完成按钮可用性逻辑
+const canSubmit = computed(() => {
+  return selectedRows.value.length > 0 && comboValid.value && isExamNoValid.value;
+});
+
+let lastClickTime = 0;
+let clickCount = 0;
+
+// 集中清空弹窗相关数据
+const clearDialogData = () => {
+  comboInput.value = '';
+  comboIp.value = '';
+  comboLensCodes.value = [];
+  comboError.value = '';
+  ruleForm.examNo = '';
+  ruleForm.ip_and_lensCode = '';
+  ruleForm.ip_and_lensCode2 = '';
+  ruleForm.patLocalid = '';
+  ruleForm.name = '';
+  ruleForm.examClass = '';
+  ruleForm.examSubclass = '';
+  ruleForm.itemName = '';
+  ruleForm.staffName = '';
+  ruleForm.examTime = '';
+  ruleForm.isAbnormal = '';
+
+  selectedRows.value = [];
+  isSelected.value = false;
+  isSearch.value = false;
+  isModify.value = false;
+  forceSubmitCount.value = 0;
+  selectedData1.value = null;
+  selectedData2.value = null;
+};
+
+// 清空选择数据
+const clearSelectedData = () => {
+  selectedRows.value = [];
+  isSelected.value = false;
+  isSearch.value = false;
+  isModify.value = false;
+  forceSubmitCount.value = 0;
+  selectedData1.value = null;
+  selectedData2.value = null;
+}
 
 // 点击添加
 const add = () => {
+  clearSelectedData();
   // 如果上一次操作是修改则清空表单
   if (isModify.value) initForm(ruleForm);
   isModify.value = false;
@@ -724,6 +924,8 @@ const add = () => {
   selectedData1.value = null; // 清空选择数据
   selectedData2.value = null; // 清空选择数据
   conRecordDialog.value = true;
+  // 新增：打开弹窗时立即触发组合号校验提示
+  comboInput.value = comboInput.value; // 触发watch，立即校验
 };
 
 // 修改时给表单进行赋值
@@ -736,174 +938,125 @@ const modify = (row: any) => {
   conRecordDialog.value = true;
 };
 
+// 完成按钮逻辑调整
 const update = async (formEl: FormInstance | undefined) => {
+  // console.log('测试信息1');
   dialogLoad.value = true;
   try {
     if (!formEl) return;
+
+    if (!isExamNoValid.value) {
+      ElMessage.error('检查唯一号必填');
+      return;
+    }
     await formEl.validate();
 
-    // 再次校验组合号和检查唯一号
-    const ipReg = /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}=[^=]+$/;
-    if (ruleForm.ip_and_lensCode && !ipReg.test(ruleForm.ip_and_lensCode)) {
-      ElMessage.error('组合号①格式不正确，示例：192.168.1.10=test');
-      dialogLoad.value = false;
-      return;
-    }
-    // 只有启用组合号②时才进行校验
-    if (enableLensCode2.value && ruleForm.ip_and_lensCode2 && !ipReg.test(ruleForm.ip_and_lensCode2)) {
-      ElMessage.error('组合号②格式不正确，示例：192.168.1.10=test');
-      dialogLoad.value = false;
-      return;
-    }
-    // 检查唯一号为空的情况不再弹窗，交给表单校验
-    if (typeof ruleForm.examNo !== 'string' || ruleForm.examNo.trim().length === 0) {
-      dialogLoad.value = false;
+    // 验证必填字段 - 组合号输入框的校验
+    if (!isComboValid.value) {
+      ElMessage.error(comboError.value);
       return;
     }
 
-    // 检查是否为修改模式，如果是修改模式则直接提交
-    if (isModify.value) {
-      const data = removeInvalid(ruleForm);
-      await conRecord.update(data);
+    // 内镜卡号数量必须大于等于选择的数据行
+    if (selectedRows.value.length > comboLensCodes.value.length) {
+      ElMessage.error("选择的数据不能多于内镜卡号数");
+      return;
+    }
+
+    // 正常批量提交
+    const ip = comboIp.value;
+    const lensArr = comboLensCodes.value;
+    if (comboValid.value && isExamNoValid.value) {
+      const batch = selectedRows.value.map((row, i) => {
+        return {
+          // 只保留row的主数据
+          examNo: row.examNo ? row.examNo : '',
+          patLocalid: row.patLocalid ? row.patLocalid : '',
+          name: row.name ? row.name : '',
+          examClass: row.examClass ? row.examClass : '',
+          examSubclass: row.examSubclass ? row.examSubclass : '',
+          itemName: row.itemName ? row.itemName : '',
+          staffName: row.staffName ? row.staffName : '',
+          examTime: row.examTime ? row.examTime : '',
+          isAbnormal: row.isAbnoraml ? row.isAbnoraml : '',
+          // 其他必需字段可补充
+          ip_and_lensCode: ip && lensArr[i] ? `${ip}=${lensArr[i]}` : '',
+          // ip_and_lensCode: `${comboIp.value}=${comboLensCodes.value[i] || ''}` // 这里确保是字符串
+        };
+      });
+      await conRecord.saveBatch(batch);
       await getList();
-      isModify.value = false;
-      isSearch.value = false;
       conRecordDialog.value = false;
+      clearDialogData();
       initForm(ruleForm);
-      dialogLoad.value = false;
+      clickCount = 0;
       return;
     }
 
-    // 新增模式下的验证逻辑
-    const currentTime = Date.now();
-
-    // 检查是否已选择检查类型
-    if (!isSelected.value) {
-      // 检查是否为强制提交（连续点击两次）
-      if (currentTime - lastSubmitTime.value < 2000) {
-        // 2秒内连续点击
-        forceSubmitCount.value++;
-        if (forceSubmitCount.value >= 2) {
-          // 强制提交前的基本验证
-          if (!ruleForm.ip_and_lensCode.trim() || !ruleForm.examNo.trim()) {
-            ElMessage.error('强制提交时组合号和检查唯一号仍为必填项');
-            dialogLoad.value = false;
-            return;
-          }
-
-          ElMessage.warning('检测到连续点击，允许强制录入诊疗信息');
-          // 强制提交逻辑
-          const data = removeInvalid(ruleForm);
-          data.forceInsert = true;
-          if (!enableLensCode2.value) data.ip_and_lensCode2 = null;
-
-          // 如果是双选模式，封装两份数据
-          if (enableLensCode2.value && selectedData1.value && selectedData2.value) {
-            const dataList = [
-              {
-                ...data,
-                ip_and_lensCode: ruleForm.ip_and_lensCode,
-                ip_and_lensCode2: null,
-                examNo: selectedData1.value.examNo,
-                patLocalid: selectedData1.value.patLocalid,
-                name: selectedData1.value.name,
-                examClass: selectedData1.value.examClass,
-                examSubclass: selectedData1.value.examSubclass,
-                itemName: selectedData1.value.itemName,
-                staffName: selectedData1.value.staffName,
-                examTime: selectedData1.value.examTime,
-                isAbnormal: selectedData1.value.isAbnoraml,
-              },
-              {
-                ...data,
-                ip_and_lensCode: ruleForm.ip_and_lensCode2,
-                ip_and_lensCode2: null,
-                examNo: selectedData2.value.examNo,
-                patLocalid: selectedData2.value.patLocalid,
-                name: selectedData2.value.name,
-                examClass: selectedData2.value.examClass,
-                examSubclass: selectedData2.value.examSubclass,
-                itemName: selectedData2.value.itemName,
-                staffName: selectedData2.value.staffName,
-                examTime: selectedData2.value.examTime,
-                isAbnormal: selectedData2.value.isAbnoraml,
-              },
-            ];
-            await conRecord.saveBatch(dataList);
-          } else {
-            const dataList = [data];
-            await conRecord.saveBatch(dataList);
-          }
-          await getList();
-          isModify.value = false;
-          isSearch.value = false;
-          conRecordDialog.value = false;
-          initForm(ruleForm);
-          forceSubmitCount.value = 0;
-          dialogLoad.value = false;
-          ruleForm.forceInsert = false;
-          return;
-        }
-      } else {
-        forceSubmitCount.value = 1;
-      }
-      lastSubmitTime.value = currentTime;
-
-      ElMessage.error('请优先查询并选择胃镜或肠镜检查类型');
-      dialogLoad.value = false;
-      return;
+    if (selectedRows.value.length === 0) {
+      ElMessage.warning('请先选择要提交的数据');
     }
 
-    // 正常提交逻辑
-    const data = removeInvalid(ruleForm);
-    if (!enableLensCode2.value) data.ip_and_lensCode2 = null;
+    if (selectedRows.value.length > 0 && lensArr.length !== selectedRows.value.length) {
+      ElMessage.warning(`已选${selectedRows.value.length}条数据，当前输入${lensArr.length}个内镜卡号，二者数量需一致`);
+    }
 
-    // 如果是双选模式，封装两份数据
-    if (enableLensCode2.value && selectedData1.value && selectedData2.value) {
-      const dataList = [
-        {
-          ...data,
-          ip_and_lensCode: ruleForm.ip_and_lensCode,
-          ip_and_lensCode2: null,
-          examNo: selectedData1.value.examNo,
-          patLocalid: selectedData1.value.patLocalid,
-          name: selectedData1.value.name,
-          examClass: selectedData1.value.examClass,
-          examSubclass: selectedData1.value.examSubclass,
-          itemName: selectedData1.value.itemName,
-          staffName: selectedData1.value.staffName,
-          examTime: selectedData1.value.examTime,
-          isAbnormal: selectedData1.value.isAbnoraml,
-        },
-        {
-          ...data,
-          ip_and_lensCode: ruleForm.ip_and_lensCode2,
-          ip_and_lensCode2: null,
-          examNo: selectedData2.value.examNo,
-          patLocalid: selectedData2.value.patLocalid,
-          name: selectedData2.value.name,
-          examClass: selectedData2.value.examClass,
-          examSubclass: selectedData2.value.examSubclass,
-          itemName: selectedData2.value.itemName,
-          staffName: selectedData2.value.staffName,
-          examTime: selectedData2.value.examTime,
-          isAbnormal: selectedData2.value.isAbnoraml,
-        },
-      ];
-      await conRecord.saveBatch(dataList);
+    // 检测一秒内连续点击两次
+    const now = Date.now();
+    if (now - lastClickTime < 1000) {
+      clickCount++;
     } else {
-      const dataList = [data];
-      await conRecord.saveBatch(dataList);
+      clickCount = 1;
     }
-    await getList();
-    isModify.value = false;
-    isSearch.value = false;
-    conRecordDialog.value = false;
-    initForm(ruleForm);
-    isSelected.value = false;
-    forceSubmitCount.value = 0;
+    lastClickTime = now;
+
+    // 强制录入逻辑
+    if (clickCount >= 2 && isComboValid.value && isExamNoValid.value) {
+      const batch = [];
+      const indexList: number[] = [];
+      if (selectedRows.value.length > 0) {
+        const batch1 = selectedRows.value.map((row, i) => {
+          indexList.push(i);
+          return {
+            // 只保留row的主数据
+            examNo: row.examNo ? row.examNo : '',
+            patLocalid: row.patLocalid ? row.patLocalid : '',
+            name: row.name ? row.name : '',
+            examClass: row.examClass ? row.examClass : '',
+            examSubclass: row.examSubclass ? row.examSubclass : '',
+            itemName: row.itemName ? row.itemName : '',
+            staffName: row.staffName ? row.staffName : '',
+            examTime: row.examTime ? row.examTime : '',
+            isAbnormal: row.isAbnoraml ? row.isAbnoraml : '',
+            ip_and_lensCode: ip && lensArr[i] ? `${ip}=${lensArr[i]}` : '',
+          };
+        });
+        batch.push(...batch1);
+      }
+
+      const batch2 = lensArr.filter((item, i) => !indexList.includes(i)).map((item, i) => {
+        return {
+          examNo: ruleForm.examNo,
+          ip_and_lensCode: ip && item ? `${ip}=${item}` : '',
+          forceInsert: true,
+        }
+      })
+      batch.push(...batch2);
+
+      await conRecord.saveBatch(batch);
+      await getList();
+      conRecordDialog.value = false;
+      clearDialogData();
+      initForm(ruleForm);
+      ElMessage.success('检测到连续点击，已触发强制录入机制');
+      dialogLoad.value = false;
+      clickCount = 0;
+    }
+    return;
+
   } catch (e) {
-    console.log(e);
+    console.log('表单验证失败', e);
+    ElMessage.error('保存失败');
   }
   dialogLoad.value = false;
 };
@@ -913,7 +1066,6 @@ const update = async (formEl: FormInstance | undefined) => {
  * @description 修复删除记录方法为Get
  * @since 2025-07-18
  */
-
 // 删除记录
 const remove = async (id: number) => {
   try {
@@ -1159,5 +1311,47 @@ header {
     border-color: #ffc107;
     color: #856404;
   }
+}
+
+.sel-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 2px solid #dcdfe6;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.sel-checkbox.checked {
+  border-color: #409eff;
+  background: #e6f7ff;
+}
+
+.sel-index {
+  font-size: 16px;
+  color: #606266;
+  font-weight: bold;
+}
+
+.sel-checkbox.checked .sel-index {
+  color: #409eff;
+}
+
+.sel-check {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  font-size: 14px;
+  color: #409eff;
+  font-weight: bold;
+}
+
+.selected-row {
+  background: #e6f7ff !important;
 }
 </style>

--- a/src/views/Hospital/HospitalInfo.vue
+++ b/src/views/Hospital/HospitalInfo.vue
@@ -1,0 +1,192 @@
+<template>
+  <header>
+    <div class="title">医院信息管理</div>
+    <div class="sub-title">
+      <span>医院管理</span>
+      <el-icon><ArrowRight /></el-icon>
+      <span>医院信息管理</span>
+    </div>
+  </header>
+  <div class="container">
+    <div class="title-box">
+      <div class="title">医院信息管理</div>
+      <my-btn color="linear-gradient(180deg, #38F9D6 0%, #3EF0A4 59.17%, #6DEE99 100%)" @click="add"
+        >添加医院信息</my-btn
+      >
+    </div>
+    <div class="content-box">
+      <el-table :data="hospitalList" style="width: 100%">
+        <el-table-column label="医院名称" prop="name"></el-table-column>
+        <el-table-column label="Logo">
+          <template #default="{ row }">
+            <img v-if="row.logoUrl" :src="row.logoUrl" class="logo-img" />
+          </template>
+        </el-table-column>
+        <el-table-column label="操作">
+          <template #default="{ row, $index }">
+            <div class="operate-btn">
+              <span @click="edit(row, $index)">编辑</span>
+              <span @click="remove($index)">删除</span>
+            </div>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
+    <el-dialog v-model="dialogVisible" title="医院信息" width="40%">
+      <el-form ref="formRef" :model="form" label-width="95px" size="large" class="form">
+        <el-form-item label="医院名称：" prop="name">
+          <el-input v-model="form.name" placeholder="请输入医院名称" />
+        </el-form-item>
+        <el-form-item label="医院Logo：">
+          <el-upload
+            class="avatar-uploader"
+            :show-file-list="false"
+            :before-upload="beforeLogoUpload"
+            :on-change="handleLogoChange"
+            :auto-upload="false"
+          >
+            <img v-if="form.logoUrl" :src="form.logoUrl" class="logo-img" />
+            <el-icon v-else class="avatar-uploader-icon"><Plus /></el-icon>
+          </el-upload>
+          <el-button v-if="form.logoUrl" type="danger" size="small" @click="removeLogo">删除</el-button>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="save">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+<script lang="ts" setup>
+import { ArrowRight, Plus } from '@element-plus/icons-vue';
+import { ref, onMounted } from 'vue';
+import { getHospitalInfo, setHospitalInfo, removeHospitalInfo } from '@/web/utils/hospitalInfo';
+
+const form = ref({
+  name: '',
+  logoUrl: '',
+});
+const formRef = ref();
+const dialogVisible = ref(false);
+const editIndex = ref(-1);
+
+const hospitalList = ref<any[]>([]);
+
+onMounted(() => {
+  // 只支持单条医院信息，兼容表格展示
+  const info = getHospitalInfo();
+  hospitalList.value = info && info.name ? [info] : [];
+});
+
+const add = () => {
+  form.value = { name: '', logoUrl: '' };
+  editIndex.value = -1;
+  dialogVisible.value = true;
+};
+
+const edit = (row: any, idx: number) => {
+  form.value = { ...row };
+  editIndex.value = idx;
+  dialogVisible.value = true;
+};
+
+const beforeLogoUpload = (file: File) => {
+  const isImage = file.type.startsWith('image/');
+  if (!isImage) {
+    ElMessage.error('只能上传图片文件');
+  }
+  return isImage;
+};
+
+const handleLogoChange = (file: any) => {
+  const reader = new FileReader();
+  reader.onload = (e: any) => {
+    form.value.logoUrl = e.target.result;
+  };
+  reader.readAsDataURL(file.raw);
+};
+
+const save = () => {
+  // 如果医院名称为null或空，自动替换为''
+  if (!form.value.name || form.value.name === null) {
+    form.value.name = ' ';
+  }
+  // 只允许一条医院信息
+  setHospitalInfo({ name: form.value.name, logoUrl: form.value.logoUrl });
+  hospitalList.value = [{ name: form.value.name, logoUrl: form.value.logoUrl }];
+  dialogVisible.value = false;
+  ElMessage.success('保存成功');
+  setTimeout(() => {
+    location.reload();
+  }, 300);
+};
+
+const remove = (idx: number) => {
+  removeHospitalInfo();
+  hospitalList.value = [];
+  ElMessage.success('已删除');
+  setTimeout(() => {
+    location.reload();
+  }, 300);
+};
+
+const removeLogo = () => {
+  form.value.logoUrl = '';
+};
+</script>
+<style lang="scss" scoped>
+header {
+  font-weight: 500;
+  font-size: 18px;
+  .sub-title {
+    margin: 20px 15px;
+    font-size: 14px;
+    color: #606266;
+    .el-icon {
+      position: relative;
+      top: 2px;
+      margin: 0 10px;
+      color: #c0c4cc;
+    }
+  }
+}
+.container {
+  padding: 20px;
+  width: 96.7%;
+  min-height: 84%;
+  background: #ffffff;
+  box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.1);
+  border-radius: 24px;
+  .title-box {
+    display: flex;
+    justify-content: space-between;
+    .title {
+      font-weight: 500;
+      font-size: 22px;
+      line-height: 30px;
+      font-feature-settings: 'tnum' on, 'lnum' on;
+      color: #303133;
+    }
+  }
+  .content-box {
+    margin-top: 20px;
+  }
+  .logo-img {
+    width: 80px;
+    height: 80px;
+    object-fit: contain;
+    border: 1px solid #eee;
+    border-radius: 8px;
+  }
+}
+.operate-btn {
+  color: #409eff;
+  span {
+    padding-left: 10px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -102,15 +102,14 @@ async function login() {
   loading.value = true;
   try {
     let { userName, password, roleId } = form;
-
-    //补上MD5加密,下次前后端开发商量好求你们
     if (isVisitor.value) {
       userName = 'visitor';
       password = '110';
       roleId = 3;
     }
-    password = CryptoJS.MD5(password).toString().toUpperCase();
     //此处删除了密码的md5加密，因为后台已经加密了，所以这里不需要加密
+    //补上MD5加密,下次前后端开发商量好求你们
+    password = CryptoJS.MD5(password).toString().toUpperCase();
     const data = { userName, password, roleId };
     const res = (await user.login(data)) as any;
     console.log(res);
@@ -161,11 +160,8 @@ onMounted(() => {
   } else if (isFirst === 'first') {
     // 初次进入系统
     speak('欢迎使用顺元消毒追溯管理系统');
-    // 自动访客登录
-    isManager.value = false;
-    isVisitor.value = true;
+    // 不再自动访客登录
     store.commit('SET_ISFIRST', 'not first');
-    login();
   }
 });
 </script>

--- a/src/views/Mirror/Record.vue
+++ b/src/views/Mirror/Record.vue
@@ -45,7 +45,7 @@
         <el-table-column prop="name" label="病人姓名" />
         <el-table-column label="状态">
           <template #default="{ row }">
-            <span v-if="row.state === 1">已结束</span>
+            <span v-if="row.state === 1">已完成</span>
             <span v-else-if="row.state === 0" style="color: #409eff">进行中</span>
             <span v-else style="color: #ff3333">异常</span>
           </template>
@@ -275,7 +275,8 @@ const download = async () => {
     //   finishTime: endTime,
     // } = row;
     // const data = { scopeName, scopeId, staffName, beginTime, endTime };
-    const res = await record.download({});
+    removeInvalid(listQuery);
+    const res = await record.download(toRaw(listQuery));
     ElMessage.success('下载成功');
     down(res, '清洗消毒记录.xlsx');
   } catch (e) {

--- a/src/web/api/conRecord.ts
+++ b/src/web/api/conRecord.ts
@@ -38,6 +38,8 @@ export default {
   },
   // 导出excel
   excel(data: any) {
-    return request.download('/logExam2/excel', data, 'get');
+    //return request.download('/logExam2/excel', data, 'get');
+    const params = new URLSearchParams(data).toString();
+    return request.download(`/logExam2/excel?${params}`, {}, 'get');
   },
 };

--- a/src/web/api/washRecord.ts
+++ b/src/web/api/washRecord.ts
@@ -11,7 +11,9 @@ export default {
   },
   // 下载记录
   download(data: any) {
-    return request.download('/down/excel', data, 'get');
+    // return request.download('/down/excel', data, 'get');
+    const params = new URLSearchParams(data).toString();
+    return request.download(`/down/excel?${params}`, {}, 'get');
   },
   getScopeRecord(data?: any) {
     return request.get('/washRecord/scope', data);

--- a/src/web/utils/hospitalInfo.ts
+++ b/src/web/utils/hospitalInfo.ts
@@ -1,0 +1,25 @@
+// 医院信息本地持久化工具
+export interface HospitalInfo {
+  name: string;
+  logoUrl: string;
+}
+
+const KEY = 'hospital_info';
+
+export function getHospitalInfo(): HospitalInfo | null {
+  const str = localStorage.getItem(KEY);
+  if (!str) return null;
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}
+
+export function setHospitalInfo(info: HospitalInfo) {
+  localStorage.setItem(KEY, JSON.stringify(info));
+}
+
+export function removeHospitalInfo() {
+  localStorage.removeItem(KEY);
+}


### PR DESCRIPTION
- 实现在一个组合号框输入多个内镜卡号
- 实现自动添加隔离符号“、”方便自动输入
- 添加复选序号框，实现自由选择批量处理的数据量
- 强制插入逻辑修改优化，允许正常数据和强插数据一起处理
- 修改提示逻辑，红色代表禁止操作提示，黄色代表警告提示但可以进行强制操作，绿色代表正常操作成功提示
- 调整操作流程顺序，支持优先通过检查唯一号进行查询病人数据，选择好数据后再进行组合号的输入
- 组合号会自动与所选数据进行匹配，数量不一致会采用不同策略智能化处理